### PR TITLE
Bit-for-bit fixes to match CAM

### DIFF
--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -424,7 +424,7 @@
               standard_name="dycore_calculates_geopotential_using_logarithms"
               units="flag" type="logical" access="protected">
       <initial_value>.false.</initial_value>
-      <initial_value dyn="SE,FV">.true.</initial_value>
+      <initial_value dyn="FV,FV3">.true.</initial_value>
     </variable>
     <ddt type="physics_state">
       <data>air_temperature</data>

--- a/src/data/registry_v1_0.xsd
+++ b/src/data/registry_v1_0.xsd
@@ -29,7 +29,7 @@
 
   <xs:simpleType name="dycore_type">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[A-Z,]+"/>
+      <xs:pattern value="[A-Z0-9,]+"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
+++ b/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
@@ -1378,7 +1378,7 @@ call pio_write_darray(file, grid_corner_lon_id, iodesc, gwork, status)
     do ie=nets,nete
 
       call convert_gbl_index(elem(ie)%vertex%number,ie1,je1,face_no)
-      start%x=r-pi/4._r8 + ie1*dx
+      start%x=-pi/4._r8 + ie1*dx
       start%y=-1._r8*pi/4._r8 + je1*dy
       endd%x  =start%x + dx
       endd%y  =start%y + dy

--- a/src/dynamics/se/dycore/dimensions_mod.F90
+++ b/src/dynamics/se/dycore/dimensions_mod.F90
@@ -52,6 +52,11 @@ module dimensions_mod
 
   integer, allocatable, public :: kord_tr(:), kord_tr_cslam(:)
 
+  ! Minimum mixing ratio of each CSLAM tracer, in CSLAM tracer index space
+  ! (1:ntrac, advected constituents only).
+  ! The mapping is done in dyn_comp from the host constituent index space.
+  real(r8), allocatable, public :: qmin_cslam(:)
+
   real(r8), allocatable, public :: nu_scale_top(:) ! scaling of del2 viscosity in sponge layer (initialized in dyn_comp)
   real(r8), allocatable, public :: nu_lev(:)       ! level dependent del4 (u,v) damping
   real(r8), allocatable, public :: nu_t_lev(:)     ! level dependent del4 T damping

--- a/src/dynamics/se/dycore/element_mod.F90
+++ b/src/dynamics/se/dycore/element_mod.F90
@@ -401,7 +401,7 @@ contains
 
     ! Allocate the SE element arrays using the pre-calculated SE dimensions
 
-    use dimensions_mod, only: nc, nlev, nlevp, qsize_d, ntrac
+    use dimensions_mod, only: nc, nlev, nlevp, qsize_d, ntrac, use_cslam
 
     !Dummy arguments:
     type(element_t), intent(inout) :: elem(:)
@@ -438,9 +438,19 @@ contains
                           file=__FILE__, line=__LINE__, errmsg=errmsg)
 
       ! Tracer mass
-      allocate(elem(i)%state%Qdp(np,np,nlev,qsize_d,2), stat=iret, errmsg=errmsg)
-      call check_allocate(iret, subname, 'elem%state%Qdp(np,np,nlev,qsize_d,2)', &
-                          file=__FILE__, line=__LINE__, errmsg=errmsg)
+      ! With CSLAM the tracers are advected on the fvm grid and the GLL Qdp is
+      ! only refreshed from it, so Qdp does not time-rotate and a single
+      ! timelevel is allocated.
+      ! TimeLevel_Qdp pins n0/np1 to 1 when use_cslam = .true.:
+      if (use_cslam) then
+        allocate(elem(i)%state%Qdp(np,np,nlev,qsize_d,1), stat=iret, errmsg=errmsg)
+        call check_allocate(iret, subname, 'elem%state%Qdp(np,np,nlev,qsize_d,1)', &
+                            file=__FILE__, line=__LINE__, errmsg=errmsg)
+      else
+        allocate(elem(i)%state%Qdp(np,np,nlev,qsize_d,2), stat=iret, errmsg=errmsg)
+        call check_allocate(iret, subname, 'elem%state%Qdp(np,np,nlev,qsize_d,2)', &
+                            file=__FILE__, line=__LINE__, errmsg=errmsg)
+      end if
 
       !--------------------------
 

--- a/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -42,8 +42,7 @@ contains
     use edgetype_mod          , only: edgebuffer_t
     use bndry_mod             , only: ghost_exchange
     use hybvcoord_mod         , only: hvcoord_t
-    use cam_constituents      , only: const_qmin
-    use dimensions_mod        , only: large_Courant_incr,irecons_tracer_lev
+    use dimensions_mod        , only: large_Courant_incr,irecons_tracer_lev,qmin_cslam
     use thread_mod            , only: vert_num_threads, omp_set_nested
     implicit none
     type (element_t)      , intent(inout) :: elem(:)
@@ -236,7 +235,7 @@ contains
               ! convert to mixing ratio
               fvm(ie)%c(i,j,k,itr) = fvm(ie)%c(i,j,k,itr)*inv_dp_area(i,j)
               ! remove round-off undershoots
-              fvm(ie)%c(i,j,k,itr) = MAX(fvm(ie)%c(i,j,k,itr),const_qmin(itr))
+              fvm(ie)%c(i,j,k,itr) = MAX(fvm(ie)%c(i,j,k,itr),qmin_cslam(itr))
             end do
           end do
         end do

--- a/src/dynamics/se/dycore/fvm_mapping.F90
+++ b/src/dynamics/se/dycore/fvm_mapping.F90
@@ -665,6 +665,12 @@ contains
         v_phys(i,2,k)=D(2,1,i)*v1 + D(2,2,i)*v2
       end do
     end do
+
+    ! Cleanup pointer components of interp_p and interpdata
+    ! to avoid memory leaks every element:
+    deallocate(interp_p%Imat, interp_p%rk, interp_p%vtemp, interp_p%glp)
+    deallocate(interpdata%interp_xy, interpdata%ilat, interpdata%ilon)
+
   end function dyn2phys_vector
 
   subroutine setup_interpdata_for_gll_to_phys_vec_mapping(interpdata,interp_p)
@@ -723,6 +729,10 @@ contains
         ioff=ioff+1
       enddo
     enddo
+
+    ! Cleanup pointers allocated by gausslobatto:
+    deallocate(gp_quadrature%points, gp_quadrature%weights)
+
   end subroutine setup_interpdata_for_gll_to_phys_vec_mapping
 
 

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -974,7 +974,7 @@ contains
             end do
           end do
         end do
-        if (molecular_diff.ne.1) then
+        if (molecular_diff>0) then
           !
           ! no frictional heating for artificial sponge
           !

--- a/src/dynamics/se/dycore/se_dyn_time_mod.F90
+++ b/src/dynamics/se/dycore/se_dyn_time_mod.F90
@@ -80,6 +80,7 @@ contains
   !locations for nm1 and n0 for Qdp - because
   !it only has 2 levels for storage
   subroutine TimeLevel_Qdp(tl, qsplit, n0, np1)
+    use dimensions_mod, only: use_cslam
     type (TimeLevel_t) :: tl
     integer, intent(in) :: qsplit
     integer, intent(inout) :: n0
@@ -87,21 +88,26 @@ contains
 
     integer :: i_temp
 
-!xxxx change when not double advecting
-    i_temp = tl%nstep/qsplit
-
-    if (mod(i_temp,2)  ==0) then
+    if (use_cslam) then
        n0 = 1
-       if (present(np1)) then
-          np1 = 2
-       endif
+       if (present(np1)) np1 = 1
     else
-       n0 = 2
-       if (present(np1)) then
-          np1 = 1
-       end if
-    endif
 
+       i_temp = tl%nstep/qsplit
+
+       if (mod(i_temp,2)  ==0) then
+          n0 = 1
+          if (present(np1)) then
+             np1 = 2
+          endif
+       else
+          n0 = 2
+          if (present(np1)) then
+             np1 = 1
+          end if
+       endif
+    !print * ,'nstep = ', tl%nstep, 'qsplit= ', qsplit, 'i_temp = ', i_temp, 'n0 = ', n0
+    endif
   end subroutine TimeLevel_Qdp
 
   subroutine TimeLevel_update(tl,uptype)

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1786,6 +1786,8 @@ subroutine read_inidat(dyn_in)
 
       if (found) then
          call read_dyn_var(trim(const_ic_name(m_cnst)), fh_ini, dimname, dbuf3)
+      else
+         dbuf3 = 0._r8
       end if
 
       do ie = 1, nelemd

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -645,11 +645,6 @@ subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
      end if
    end do
 
-   ! DEBUG -JN:
-   do m=1, num_advected
-     write(iulog, *) 'DEBUG -JN adv_const_dx: ', advected_constituent_index(m), m
-   end do
-
    ! Finalize statediag_numtrac now that the number of advected
    ! constituents is known (qsize is set by dimensions_mod_init, which runs
    ! after cam_register_constituents).

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -565,6 +565,7 @@ subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
    use dimensions_mod,     only: ksponge_end, kmvis_ref, kmcnd_ref,rho_ref,km_sponge_factor
    use dimensions_mod,     only: cnst_name_gll, cnst_longname_gll, use_cslam
    use dimensions_mod,     only: irecons_tracer_lev, irecons_tracer, kord_tr, kord_tr_cslam
+   use dimensions_mod,     only: qmin_cslam
    use prim_driver_mod,    only: prim_init2
    use se_dyn_time_mod,    only: time_at
    use control_mod,        only: runtype, nu_top, molecular_diff
@@ -682,6 +683,17 @@ subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
                          file=__FILE__, line=__LINE__, errmsg=errmsg)
 
      kord_tr_cslam(:) = vert_remap_tracer_alg
+
+     allocate(qmin_cslam(ntrac), stat=iret, errmsg=errmsg)
+     call check_allocate(iret, subname, 'qmin_cslam(ntrac)', &
+                         file=__FILE__, line=__LINE__, errmsg=errmsg)
+
+     ! CSLAM indexes its tracers 1:ntrac (advected constituents only), while
+     ! const_qmin takes a constituent index, so translate here rather than
+     ! inside the dycore.
+     do m = 1, ntrac
+       qmin_cslam(m) = const_qmin(advected_constituent_index(m))
+     end do
    end if
 
    do m=1,qsize
@@ -701,7 +713,14 @@ subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
        ! note that in this case qsize = thermodynamic_active_species_num
        !
        thermodynamic_active_species_idx_dycore(m) = m
-       kord_tr_cslam(thermodynamic_active_species_idx(m)) = vert_remap_uvTq_alg
+       ! kord_tr_cslam is in CSLAM tracer index space (1:ntrac), so map this
+       ! species constituent index into it instead of indexing it directly.
+       do mfound = 1, ntrac
+         if (advected_constituent_index(mfound) == thermodynamic_active_species_idx(m)) then
+           kord_tr_cslam(mfound) = vert_remap_uvTq_alg
+           exit
+         end if
+       end do
        kord_tr(m)                                 = vert_remap_uvTq_alg
        cnst_name_gll    (m)                       = const_name    (thermodynamic_active_species_idx(m))
        cnst_longname_gll(m)                       = const_longname(thermodynamic_active_species_idx(m))


### PR DESCRIPTION
After these fixes the SE dycore is bit-for-bit on FADIAB `ne16_ne16_mg17` and the pg config `ne16pg3_ne16pg3_mg17` (note that the analytic ic has to be changed in the CAM-SIMA namelist to match CAM).

There were about four fixes total. I also added a few memory leak fixes as the SIMA CSLAM run was leaking memory at every spectral element.

Courtesy of dropsonde.

Note that this has to be tested on `FADIAB` (pure dycore), not `FKESSLER`: on FKESSLER ne5 the second step starts diverging due to differences in the physics coupling path: Claude says the reason is:
```
- CAM (kessler_cam.F90:275 + physics_types.F90:419): ptend%s = (θ·pk − T)·cpairv/Δt, then dtdt = ptend%s/cpairv — a multiply-by-cp-then-divide-by-cp round trip.
- SIMA (kessler_update.F90:80): ttend_t = (θ·exner − T_prev)/Δt — direct, no cp round trip.
```